### PR TITLE
conanbuildinfo.cmake requires v2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
+cmake_minimum_required(VERSION 2.8.12)
 PROJECT(conanpoco)
-cmake_minimum_required(VERSION 2.8)
 include(${CMAKE_CURRENT_SOURCE_DIR}/../conanbuildinfo.cmake)
 CONAN_BASIC_SETUP()
 


### PR DESCRIPTION
See also https://github.com/conan-io/conan/issues/1968.
