### PR TITLE
Release/1.8.0.1

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -112,7 +112,7 @@ cxx_14=False
             cmake.definitions["POCO_MT"] = "ON" if "MT" in str(self.settings.compiler.runtime) else "OFF"
         self.output.info(cmake.definitions)
         os.mkdir("build")
-        cmake.configure(source_dir="../poco", build_dir="build")
+        cmake.configure(source_dir="./poco", build_dir="build")
         cmake.build()
 
     def package(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -112,7 +112,7 @@ cxx_14=False
             cmake.definitions["POCO_MT"] = "ON" if "MT" in str(self.settings.compiler.runtime) else "OFF"
         self.output.info(cmake.definitions)
         os.mkdir("build")
-        cmake.configure(source_dir="./poco", build_dir="build")
+        cmake.configure(source_dir="poco", build_dir="build")
         cmake.build()
 
     def package(self):


### PR DESCRIPTION
All your builds are still failing because of other breaking change in 0.30, the CMake() build helper now uses different behavior for relative paths (now relative to `self.source_folder`)
Thanks again