### PR TITLE
Fix again

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -112,7 +112,7 @@ cxx_14=False
             cmake.definitions["POCO_MT"] = "ON" if "MT" in str(self.settings.compiler.runtime) else "OFF"
         self.output.info(cmake.definitions)
         os.mkdir("build")
-        cmake.configure(source_dir="poco", build_dir="build")
+        cmake.configure(source_dir="../poco", build_dir="build")
         cmake.build()
 
     def package(self):


### PR DESCRIPTION
Hi, we have released Conan 0.30.3 to revert the breaking changes. 
All the packages of OpenSSL and other recursive deps should be ok for gcc 5,6,7.

Thanks!!