### PR TITLE
Fix link errors on Windows

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -182,4 +182,4 @@ cxx_14=False
         if not self.options.shared:
             self.cpp_info.defines.extend(["POCO_STATIC=ON", "POCO_NO_AUTOMATIC_LIBS"])
             if self.settings.compiler == "Visual Studio":
-                self.cpp_info.libs.extend(["ws2_32", "Iphlpapi.lib", "Crypt32.lib"])
+                self.cpp_info.libs.extend(["ws2_32", "Iphlpapi", "Crypt32"])


### PR DESCRIPTION
The current conanfile.py generates 

`-lws2_32 -lIphlpapi.lib -lCrypt32.lib` 

for the link flags which causes error as the linker looks for `Iphlpapi.lib.lib` and `Crypt32.lib.lib` files.
Removing the extra `.lib` can fix this issue.