### PR TITLE
Apple clang 9.1 and OpenSSL 1.0.2o

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,15 @@ matrix:
       - <<: *osx
         osx_image: xcode9
         env: CONAN_APPLE_CLANG_VERSIONS=9.0 CONAN_CURRENT_PAGE=3
+      - <<: *osx
+        osx_image: xcode9.3beta
+        env: CONAN_APPLE_CLANG_VERSIONS=9.1 CONAN_CURRENT_PAGE=1
+      - <<: *osx
+        osx_image: xcode9.3beta
+        env: CONAN_APPLE_CLANG_VERSIONS=9.1 CONAN_CURRENT_PAGE=2
+      - <<: *osx
+        osx_image: xcode9.3beta
+        env: CONAN_APPLE_CLANG_VERSIONS=9.1 CONAN_CURRENT_PAGE=3
 
 install:
   - chmod +x .travis/install.sh

--- a/conanfile.py
+++ b/conanfile.py
@@ -87,7 +87,7 @@ cxx_14=False
 
     def requirements(self):
         if self.options.enable_netssl or self.options.enable_netssl_win or self.options.enable_crypto or self.options.force_openssl:
-            self.requires.add("OpenSSL/1.0.2n@conan/stable", private=False)
+            self.requires.add("OpenSSL/1.0.2o@conan/stable", private=False)
 
         if self.options.enable_data_mysql:
             # self.requires.add("MySQLClient/6.1.6@hklabbers/stable")


### PR DESCRIPTION
Hi!
This PR adds support to generate apple-clang 9.1 packages and changes the OpenSSL dep to the latest stable.
Would be nice to have it merged before the next Tuesday, we are going to ACCU conference and I run many conan demos using Poco, and my macbook got updated to clang 9.1 and We've not binary packages 🤣 

Thanks