### PR TITLE
Use OpenSSL includes when NetSSL_Win is disabled

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -173,8 +173,6 @@ cxx_14=False
                  else ("d" if self.settings.build_type=="Debug" else "")
         for flag, lib in libs:
             if getattr(self.options, flag):
-                if self.settings.os == "Windows" and flag == "enable_netssl":
-                    continue
                 if self.settings.os != "Windows" and flag == "enable_netssl_win":
                     continue
                 self.cpp_info.libs.append("%s%s" % (lib, suffix))

--- a/conanfile.py
+++ b/conanfile.py
@@ -131,7 +131,7 @@ cxx_14=False
         packages = ["CppUnit", "Crypto", "Data", "Data/MySQL", "Data/ODBC", "Data/SQLite",
                     "Foundation", "JSON", "MongoDB", "Net", "Util",
                     "XML", "Zip"]
-        if self.settings.os == "Windows":
+        if self.settings.os == "Windows" and self.options.enable_netssl_win:
             packages.append("NetSSL_Win")
         else:
             packages.append("NetSSL_OpenSSL")


### PR DESCRIPTION
Package method decides which includes are used only by a platform. On Windows `NetSSL_Win` folder is always used. When `enable_netssl_win=False` CMake use folder `NetSSL_OpenSSL` but Conan recipe uses includes from `NetSSL_Win` folder.  Let's take into consideration also `enable_netssl_win` in the recipe.