### PR TITLE
Remove lib extension

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -187,4 +187,4 @@ cxx_14=False
         if not self.options.shared:
             self.cpp_info.defines.extend(["POCO_STATIC=ON", "POCO_NO_AUTOMATIC_LIBS"])
             if self.settings.compiler == "Visual Studio":
-                self.cpp_info.libs.extend(["ws2_32", "Iphlpapi.lib", "Crypt32.lib"])
+                self.cpp_info.libs.extend(["ws2_32", "Iphlpapi", "Crypt32"])


### PR DESCRIPTION
Specifying the `lib` extension is causing some troubles with Conan in some situations. Is more compatible to specify only the library name. Let's see if the CI is ok with that.