### PR TITLE
Added POCO_NO_FORK_EXEC flag to tvOS and watchOS builds

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -116,6 +116,9 @@ cxx_14=False
             elif not option_name == "fPIC":
                 cmake.definitions[option_name.upper()] = "ON" if activated else "OFF"
 
+        if self.settings.os == "tvOS" or self.settings.os == "watchOS":
+            cmake.definitions["CONAN_CXX_FLAGS"] = "-DPOCO_NO_FORK_EXEC"
+
         if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":  # MT or MTd
             cmake.definitions["POCO_MT"] = "ON" if "MT" in str(self.settings.compiler.runtime) else "OFF"
         self.output.info(cmake.definitions)

--- a/conanfile.py
+++ b/conanfile.py
@@ -93,7 +93,7 @@ cxx_14=False
 
     def requirements(self):
         if self.options.enable_netssl or self.options.enable_netssl_win or self.options.enable_crypto or self.options.force_openssl:
-            self.requires.add("OpenSSL/1.0.2o@conan/stable", private=False)
+            self.requires.add("libressl/2.5.3@conan/stable", private=False)
 
         if self.options.enable_data_mysql:
             # self.requires.add("MySQLClient/6.1.6@hklabbers/stable")


### PR DESCRIPTION
Fixed building Poco for tvOS and watchOS. I'm not sure this is the best way to fix the problem though, any better suggestions?