### PR TITLE
fix windows wrong linkage of ssl libraries

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -173,10 +173,15 @@ cxx_14=False
         suffix = str(self.settings.compiler.runtime).lower()  \
                  if self.settings.compiler == "Visual Studio" and not self.options.shared \
                  else ("d" if self.settings.build_type=="Debug" else "")
+
         for flag, lib in libs:
             if getattr(self.options, flag):
+                if self.settings.os == "Windows" and flag == "enable_netssl" and self.options.enable_netssl_win:
+                    continue
+                
                 if self.settings.os != "Windows" and flag == "enable_netssl_win":
                     continue
+
                 self.cpp_info.libs.append("%s%s" % (lib, suffix))
 
         self.cpp_info.libs.append("PocoFoundation%s" % suffix)


### PR DESCRIPTION
fix windows wrong linkage of ssl libraries

- this fix let only one or other be linked